### PR TITLE
A few typos in cpu_6502.txt

### DIFF
--- a/src/6502/cpu_6502.txt
+++ b/src/6502/cpu_6502.txt
@@ -855,15 +855,15 @@ TAX  Transfer Accumulator To Index X
 
 TXA  Transfer Index X To Accumulator
      This instruction moves the value that is in the index register X to the accumulator A without disturbing the content of the index register X.
-     TXA does not affect any register other than the accumula­tor and does not affect the carry or overflow flag. If the result in A has bit 7 on, then the N flag is set, otherwise it is reset. If the resultant value in the accumulator is 0, then the Z flag is set, other­ wise it is reset.
+     TXA does not affect any register other than the accumulator and does not affect the carry or overflow flag. If the result in A has bit 7 on, then the N flag is set, otherwise it is reset. If the resultant value in the accumulator is 0, then the Z flag is set, other­ wise it is reset.
 
-TAY  Transfer Accumula Tor To Index Y
+TAY  Transfer Accumulator To Index Y
      This instruction moves the value of the accumulator into index register Y without affecting the accumulator.
      TAY instruction only affects the Y register and does not affect either the carry or overflow flags. If the index register Y has bit 7 on, then N is set, otherwise it is reset. If the content of the index register Y equals 0 as a result of the operation, Z is set on, otherwise it is reset.
 
 TYA  Transfer Index Y To Accumulator
      This instruction moves the value that is in the index register Y to accumulator A without disturbing the content of the register Y.
-     TYA does not affect any other register other than the accumula­ tor and does not affect the carry or overflow flag. If the result in the accumulator A has bit 7 on, the N flag is set, otherwise it is reset. If the resultant value in the accumulator A is 0, then the Z flag is set, otherwise it is reset.
+     TYA does not affect any other register other than the accumulator and does not affect the carry or overflow flag. If the result in the accumulator A has bit 7 on, the N flag is set, otherwise it is reset. If the resultant value in the accumulator A is 0, then the Z flag is set, otherwise it is reset.
 
 JSR  Jump To Subroutine
      This instruction transfers control of the program counter to a subroutine location but leaves a return pointer on the stack to allow the user to return to perform the next instruction in the main program after the subroutine is complete. To accomplish this, JSR instruction stores the program counter address which points to the last byte of the jump instruc­ tion onto the stack using the stack pointer. The stack byte contains the program count high first, followed by program count low. The JSR then transfers the addresses following the jump instruction to the program counter low and the program counter high, thereby directing the program to begin at that new address.


### PR DESCRIPTION
I found some (OCR?) errors regarding the spelling of "Accumulator"

It is *very* obvious here:
![grafik](https://github.com/user-attachments/assets/47099b79-5cf9-491b-9932-ffd245c6a67d)


BTW: found by regExp /accumula[^Tt]+\S+/i

- fixed some (OCR?) errors regarding the spelling of "Accumulator"
- some (hidden) UTF-8 non-space character, too